### PR TITLE
Make compatibility with rack v2.x explicit

### DIFF
--- a/rack-www.gemspec
+++ b/rack-www.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'rack', '~> 1.0'
+  s.add_runtime_dependency 'rack', '< 3.0'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'minitest', '~> 5.8'


### PR DESCRIPTION
So that rack-www can be used in projects that use rack v2.x, e.g. those based on rails v5.x as well as those that depend on rack v1.x
