### PR TITLE
(feat) Allow host-regex option to limit redirect to matched hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ You can optionally specify predicate to determine if redirect should take place:
   }
 ```
 
+Specifying host-regex to determine on what hosts to redirect:
+
+```ruby
+  config.middleware.use Rack::WWW, :host_regex => /example/i
+```
+This will only redirect when the host matches `example`, such as `example.com` or `example1.com`. It won't redirect on `localhost` or any other host that does not match the regex
+
 It ignores any redirects when using IP addresses.
 
 ### Options

--- a/lib/rack/www.rb
+++ b/lib/rack/www.rb
@@ -12,6 +12,7 @@ module Rack
       @redirect = !@options[:www].nil? ? @options[:www] : true
       @message = @options[:message]
       @subdomain = @options[:subdomain]
+      @host_regex = @options[:host_regex] || /.+/i
       @predicate = @options[:predicate]
     end
 
@@ -38,7 +39,8 @@ module Rack
     end
 
     def redirect?(env)
-      predicate?(env) && change_subdomain?(env) && !ip_request?(env)
+      predicate?(env) && change_subdomain?(env) && !ip_request?(env) &&
+        matches_host?(env)
     end
 
     def predicate?(env)
@@ -64,6 +66,10 @@ module Rack
 
     def already_subdomain?(env)
       env['HTTP_HOST'].to_s.downcase =~ /^(#{@subdomain}\.)/
+    end
+
+    def matches_host?(env)
+      env['HTTP_HOST'].to_s.downcase =~ @host_regex
     end
 
     def prepare_url(env)


### PR DESCRIPTION
Had issues with staging and development environments redirecting while trying to run the app in a non-production environment. This allows a regex option to limit redirection to only if the host matches the regex passed in.